### PR TITLE
fix: Trigger release on short-circuit commit of OUI changes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,10 @@ on:
   push:
     branches:
       - master
+  workflow_run:
+    workflows: ["Fetch and commit OUI content"]
+    types:
+      - completed
 
 jobs:
   release:


### PR DESCRIPTION
The workflow that fetches/merges OUI changes was not triggering a release; per https://stackoverflow.com/a/65698892 this PR should cause that to begin occurring