### PR TITLE
Add helper to pin GitHub Action digests to semver

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,7 +13,8 @@
     }
   ],
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "helpers:pinGitHubActionDigestsToSemver"
   ],
   "labels": [
     "dependencies"


### PR DESCRIPTION
hopefully this will pin to digests but also bump the commented version to X.Y.Z semver