### PR TITLE
Add helper to pin GitHub Action digests to semver

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,7 +13,8 @@
     }
   ],
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "helpers:pinGitHubActionDigestsToSemver"
   ],
   "labels": [
     "dependencies"


### PR DESCRIPTION
Hopefully this will cause actions to be pinned to digest but the commented version expanded to semver X.Y.Z